### PR TITLE
No more 2.0 snapshot

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.spongepowered
 name = play-discourse
-version = 2.0.0-SNAPSHOT
+version = 2.0.0


### PR DESCRIPTION
2.0 should no longer be considered a snapshot. It also slows down the main Ore build a slight bit.